### PR TITLE
Fix Omega Ray not aborting correctly

### DIFF
--- a/SpaceInvadersProject/Assets/Prefabs/Entities/OmegaRay.prefab
+++ b/SpaceInvadersProject/Assets/Prefabs/Entities/OmegaRay.prefab
@@ -259,7 +259,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   duration: 2
-  chargeTime: 4
+  chargeTime: 5
   doDamageOnCollision:
     serializedVersion: 2
     m_Bits: 896

--- a/SpaceInvadersProject/Assets/Scenes/GameScene.unity
+++ b/SpaceInvadersProject/Assets/Scenes/GameScene.unity
@@ -280,7 +280,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!114 &519420030
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/SpaceInvadersProject/Assets/Scripts/Controllers/PlayerController.cs
+++ b/SpaceInvadersProject/Assets/Scripts/Controllers/PlayerController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using UnityEngine;
 
@@ -6,6 +7,8 @@ namespace SpaceInvaders
     [RequireComponent(typeof(Animator))]
     public class PlayerController : EntityController
     {
+        public event EventHandler Exploding;
+
         [SerializeField, Header("Key Bindings")]
         private KeyCode fireLaserKey = KeyCode.Space;
         [SerializeField]
@@ -36,6 +39,12 @@ namespace SpaceInvaders
             }
         }
 
+        public override void Destroy()
+        {
+            Exploding?.Invoke(this, EventArgs.Empty);
+            base.Destroy();
+        }
+
         protected override void Awake()
         {
             base.Awake();
@@ -55,6 +64,25 @@ namespace SpaceInvaders
 
         private void Update()
         {
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
+            // Sepukku
+            if (Input.GetKeyDown(KeyCode.D))
+            {
+                Destroy();
+            }
+
+            // Developer God mode
+            if (Input.GetKeyDown(KeyCode.G))
+            {
+                maxHP = Health = 10000;
+                FindObjectOfType<ProjectileSpawner>().maxPrimaryProjectilesActive = 10;
+                FindObjectOfType<ProjectileSpawner>().maxSecondaryProjectilesActive = 10;
+                FindObjectOfType<ProjectileSpawner>().gainSecondaryEveryNShots = 1;
+                omegaRay.duration = pulseShield.duration = 5f;
+                omegaRay.chargeTime = pulseShield.rechargeTime = 0.5f;
+            }
+#endif
+
             if (IsExploding || omegaRay.IsFiring)
             {
                 return;
@@ -79,24 +107,6 @@ namespace SpaceInvaders
             {
                 DeployPulseShield();
             }
-
-#if DEVELOPMENT_BUILD || UNITY_EDITOR
-            // Sepukku
-            if (Input.GetKeyDown(KeyCode.D))
-            {
-                Destroy();
-            }
-
-            // Developer God mode
-            if (Input.GetKeyDown(KeyCode.G))
-            {
-                maxHP = Health = 10000;
-                FindObjectOfType<ProjectileSpawner>().maxPrimaryProjectilesActive = 10;
-                FindObjectOfType<ProjectileSpawner>().maxSecondaryProjectilesActive = 10;
-                omegaRay.duration = pulseShield.duration = 5f;
-                omegaRay.chargeTime = pulseShield.rechargeTime = 0.5f;
-            }
-#endif
         }
 
         private void FixedUpdate()

--- a/SpaceInvadersProject/Assets/Scripts/Managers/ProjectileSpawner.cs
+++ b/SpaceInvadersProject/Assets/Scripts/Managers/ProjectileSpawner.cs
@@ -14,7 +14,7 @@ namespace SpaceInvaders
         [SerializeField, Range(1, 10)]
         private int maxInvaderProjectilesActive = 3;
         [SerializeField, Range(1, 100), Space]
-        private int gainSecondaryEveryNShots = 10;
+        public int gainSecondaryEveryNShots = 10;
         [SerializeField, Space]
         private PlayerResourceManager secondaryResourceManager;
 

--- a/SpaceInvadersProject/Assets/Scripts/ScreenDistorter.cs
+++ b/SpaceInvadersProject/Assets/Scripts/ScreenDistorter.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering.PostProcessing;
 
@@ -14,6 +13,7 @@ namespace SpaceInvaders
         private AnimationCurve distortionCurve;
 
         private ChromaticAberration chromaticAberration;
+        private float defaultDistortion;
 
         private float Distortion
         {
@@ -23,7 +23,13 @@ namespace SpaceInvaders
 
         public void DistortScreen(float duration)
         {
-            StartCoroutine(ScreenDistortionCoroutine(duration));
+            _ = StartCoroutine(ScreenDistortionCoroutine(duration));
+        }
+
+        public void Abort()
+        {
+            StopAllCoroutines();
+            Distortion = defaultDistortion;
         }
 
         private void Awake()
@@ -31,11 +37,12 @@ namespace SpaceInvaders
             Camera mainCamera = Camera.main;
             PostProcessVolume volume = mainCamera.GetComponent<PostProcessVolume>();
             chromaticAberration = volume.profile.settings.Find(effect => effect is ChromaticAberration) as ChromaticAberration;
+            defaultDistortion = Distortion;
         }
 
         private IEnumerator ScreenDistortionCoroutine(float duration)
         {
-            float original = Distortion;
+            defaultDistortion = Distortion;
 
             float time = 0f;
             while (time < duration)
@@ -48,7 +55,7 @@ namespace SpaceInvaders
                 yield return null;
             }
 
-            Distortion = original;
+            Distortion = defaultDistortion;
         }
     }
 }


### PR DESCRIPTION
Fix issue where the Omega Ray would not abort correctly when the player is destroyed, leaving the screen permanently distorted.

Other changes:
- Increase Omega Ray's charging time from 4 to 5 seconds.
- Add `event Exploding` to `PlayerController`.
- Disable main camera's audio listener (not in use).

Fixes #1 